### PR TITLE
Add HybridFix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a SDK to integrate raytracing anti-xray into your Spigot/Paper fork, wit
 - [1.8.8 ImanitySpigot3](https://builtbybit.com/resources/imanityspigot3-regular.10770/)
 - [1.21.4 Leaf](https://github.com/Winds-Studio/Leaf/)
 - [1.21.x UniverseSpigot](https://discord.universespigot.com/)
+- [1.12.2 HybridFix (Mod brings SDK integration into hybrid servers)](https://github.com/HaHaWTH/HybridFix/)
 
 ## Why should you care? (as a developer of a Spigot/Paper fork)
 


### PR DESCRIPTION
[HybridFix](https://github.com/HaHaWTH/HybridFix/) brings AntiXray integration support into 1.12.2 hybrid servers.

Tested on 1.12.2 CatServer/Mohist(with updated FastUtil), works fine without issues( ´▽` )